### PR TITLE
Initial commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# DocumentDB Emulator Dockerfile
+
+# Indicates that the windowsservercore image will be used as the base image.
+FROM microsoft/windowsservercore
+
+# Metadata indicating an image maintainer.
+MAINTAINER mominag@microsoft.com
+
+# Add the DocumentDB installer msi into the package
+ADD https://aka.ms/documentdb-emulator c:\\DocumentDBEmulator\\DocumentDB.Emulator.msi
+
+# Copy misc scripts into the package
+COPY package_scripts\\startemu.cmd c:\\DocumentDBEmulator\\startemu.cmd
+COPY package_scripts\\getaddr.ps1 c:\\DocumentDBEmulator\\getaddr.ps1
+COPY package_scripts\\exportcert.ps1 c:\\DocumentDBEmulator\\exportcert.ps1
+COPY package_scripts\\importcert.ps1 c:\\DocumentDBEmulator\\importcert.ps1
+
+# Install the MSI
+RUN echo "Starting Installer"
+RUN powershell.exe -Command $ErrorActionPreference = 'Stop'; \
+   Start-Process 'msiexec.exe' -ArgumentList '/i','c:\DocumentDBEmulator\DocumentDB.Emulator.msi','/qn' -Wait
+RUN echo "Installer Done"
+
+# Expose the required network ports
+EXPOSE 8081
+EXPOSE 10250
+EXPOSE 10251
+EXPOSE 10252
+EXPOSE 10253
+EXPOSE 10254
+
+# Start the interactive shell
+CMD [ "c:\\DocumentDBEmulator\\startemu.cmd" ]

--- a/mk.cmd
+++ b/mk.cmd
@@ -1,0 +1,1 @@
+docker build -t documentdb_emulator .

--- a/package_scripts/exportcert.ps1
+++ b/package_scripts/exportcert.ps1
@@ -1,0 +1,3 @@
+$pass = ConvertTo-SecureString -String "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" -Force -AsPlainText
+$cert = Get-ChildItem cert:\LocalMachine\My | Where-Object {$_.FriendlyName -eq "DocumentDbEmulatorCertificate" }
+$output = Export-PfxCertificate -Cert $cert -FilePath c:\DocumentDBEmulator\DocumentDBEmulatorCert\DocumentDBEmulatorCert.pfx -Password $pass

--- a/package_scripts/getaddr.ps1
+++ b/package_scripts/getaddr.ps1
@@ -1,0 +1,4 @@
+$addrObj = (Get-NetIPAddress -AddressFamily IPV4 -AddressState Preferred -PrefixOrigin Manual | Select IPAddress)
+$addr = $addrObj.IPAddress
+$result = "Emulator Endpoint: https://" + $addr + ":8081/"
+echo $result

--- a/package_scripts/importcert.ps1
+++ b/package_scripts/importcert.ps1
@@ -1,0 +1,3 @@
+$pass = ConvertTo-SecureString -String "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" -Force -AsPlainText
+$output = Import-PfxCertificate -FilePath .\DocumentDBEmulatorCert.pfx cert:\localMachine\my -Password $pass
+$output = Import-PfxCertificate -FilePath .\DocumentDBEmulatorCert.pfx cert:\localMachine\root -Password $pass

--- a/package_scripts/startemu.cmd
+++ b/package_scripts/startemu.cmd
@@ -1,0 +1,18 @@
+@echo off
+echo Starting Emulator
+rem start /WAIT "" "c:\Program Files\DocumentDB Emulator\DocumentDB.Emulator.exe" /noui /GenKeyFile=c:\DocumentDBEmulator\keyfile.txt 
+rem start "" "c:\Program Files\DocumentDB Emulator\DocumentDB.Emulator.exe" /noui /AllowNetworkAccess /NoFirewall /KeyFile=c:\DocumentDBEmulator\keyfile.txt
+rem echo Authorization key:
+rem type c:\DocumentDBEmulator\keyfile.txt
+start "" "c:\Program Files\DocumentDB Emulator\DocumentDB.Emulator.exe" /noui /AllowNetworkAccess /NoFirewall /Key=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+powershell -File c:\DocumentDBEmulator\getaddr.ps1
+echo Master Key: C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
+echo Exporting SSL Certificate
+powershell -File c:\DocumentDBEmulator\exportcert.ps1
+copy /y c:\DocumentDBEmulator\importcert.ps1 c:\DocumentDBEmulator\DocumentDBEmulatorCert >nul
+echo You can import the SSL certificate from an administrator command prompt on the host by running:
+echo cd /d ^%%LOCALAPPDATA^%%\DocumentDBEmulatorCert
+echo powershell .\importcert.ps1
+echo --------------------------------------------------------------------------------------------------
+echo Starting interactive shell
+cmd /K

--- a/run.cmd
+++ b/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+md %LOCALAPPDATA%\DocumentDBEmulatorCert 2>nul
+docker run -v %LOCALAPPDATA%\DocumentDBEmulatorCert:c:\DocumentDBEmulator\DocumentDBEmulatorCert -P -t -i documentdb_emulator


### PR DESCRIPTION
To build the Azure DocumentDB Emulator Docker package, you can use mk.cmd (or docker build -t documentdb_emulator .)
To start the docker image, you can use run.cmd.  Note that the package will start an interactive shell with the following information:
- The endpoint and access key for the emulator.
- Instructions on importing the SSL certificates to your host machine.